### PR TITLE
Implement Tarjan generator with tests

### DIFF
--- a/src/utils/tarjan.test.ts
+++ b/src/utils/tarjan.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "bun:test";
+import { tarjanStepByStep, Graph } from "./tarjan";
+
+const simpleGraph: Graph = {
+  nodes: [{ id: "a" }, { id: "b" }],
+  edges: [
+    { from: "a", to: "b" },
+    { from: "b", to: "a" },
+  ],
+};
+
+describe("tarjanStepByStep", () => {
+  it("yields visit action first", () => {
+    const gen = tarjanStepByStep(simpleGraph);
+    const step = gen.next().value;
+    expect(step.action).toBe("visit");
+    expect(step.currentNode).toBe("a");
+  });
+
+  it("finds a single strongly connected component", () => {
+    const gen = tarjanStepByStep(simpleGraph);
+    let last;
+    for (const s of gen) {
+      last = s;
+    }
+    expect(last?.sccs.length).toBe(1);
+    expect(new Set(last?.sccs[0])).toEqual(new Set(["a", "b"]));
+  });
+});


### PR DESCRIPTION
## Summary
- implement `tarjanStepByStep` generator in `src/utils`
- integrate generator into algo store `stepForward`
- add unit tests for the generator

## Testing
- `bun run format`
- `bun run lint`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_687ca313f1d483259a763de1d6564fd1