### PR TITLE
Integrate graph store with ReactFlow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,15 +5,14 @@ import { useGraphStore } from "./store/graphStore";
 export default function App() {
   console.log("render app");
   const setEditMode = useGraphStore((s) => s.setEditMode);
-  const resetGraphState = useGraphStore((s) => s.resetGraphState);
+  const resetGraph = useGraphStore((s) => s.resetGraph);
   const startAutoRun = useGraphStore((s) => s.startAutoRun);
   const stopAutoRun = useGraphStore((s) => s.stopAutoRun);
   const autoRun = useGraphStore((s) => s.algoState?.autoRun ?? false);
 
   const handleResetGraph = () => {
     if (confirm("Voulez-vous vraiment effacer le graphe ?")) {
-      resetGraphState();
-      window.dispatchEvent(new Event("reset-graph"));
+      resetGraph();
     }
   };
 

--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -15,7 +15,7 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import { useGraphStore } from "../store/graphStore";
 import { useAlgoStore } from "../store/algoState";
-import { shallow } from "zustand/shallow";
+import { useShallow } from "zustand/react/shallow";
 
 const sccColors = [
   "#fca5a5",
@@ -41,12 +41,11 @@ export default function GraphCanvas() {
   const editable = useGraphStore((s) => s.editable);
 
   const algo = useAlgoStore(
-    (s) => ({
+    useShallow((s) => ({
       indexMap: s.indexMap,
       onStackMap: s.onStackMap,
       sccs: s.sccs,
-    }),
-    shallow,
+    })),
   );
 
   const getNodeColor = useCallback(

--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -101,7 +101,18 @@ export default function GraphCanvas() {
         label: n.data.label,
         position: n.position,
       }));
-      setGraphNodes(updatedGraph);
+      const equal =
+        updatedGraph.length === nodes.length &&
+        updatedGraph.every(
+          (n, i) =>
+            n.id === nodes[i].id &&
+            n.label === nodes[i].label &&
+            n.position.x === nodes[i].position.x &&
+            n.position.y === nodes[i].position.y,
+        );
+      if (!equal) {
+        setGraphNodes(updatedGraph);
+      }
     },
     [nodes, setGraphNodes],
   );
@@ -119,7 +130,17 @@ export default function GraphCanvas() {
         from: e.source,
         to: e.target,
       }));
-      setGraphEdges(updatedGraph);
+      const equal =
+        updatedGraph.length === edges.length &&
+        updatedGraph.every(
+          (e, i) =>
+            e.id === edges[i].id &&
+            e.from === edges[i].from &&
+            e.to === edges[i].to,
+        );
+      if (!equal) {
+        setGraphEdges(updatedGraph);
+      }
     },
     [edges, setGraphEdges],
   );

--- a/src/store/graphStore.ts
+++ b/src/store/graphStore.ts
@@ -46,6 +46,9 @@ interface GraphStore {
   addNode: (node: GraphNode) => void;
   addEdge: (edge: GraphEdge) => void;
   removeNode: (id: NodeId) => void;
+  removeEdge: (id: string) => void;
+  setNodes: (nodes: GraphNode[]) => void;
+  setEdges: (edges: GraphEdge[]) => void;
   setEditable: (value: boolean) => void;
   resetGraph: () => void;
   /** @deprecated use resetGraph */
@@ -92,6 +95,21 @@ export const useGraphStore = create<GraphStore>((set, get) => ({
       nodes: s.nodes.filter((n) => n.id !== id),
       edges: s.edges.filter((e) => e.from !== id && e.to !== id),
     }));
+  },
+
+  removeEdge: (id) => {
+    useAlgoStore.getState().resetAlgo();
+    set((s) => ({ edges: s.edges.filter((e) => e.id !== id) }));
+  },
+
+  setNodes: (nodes) => {
+    useAlgoStore.getState().resetAlgo();
+    set({ nodes });
+  },
+
+  setEdges: (edges) => {
+    useAlgoStore.getState().resetAlgo();
+    set({ edges });
   },
 
   setEditable: (value) => set({ editable: value }),


### PR DESCRIPTION
## Summary
- use nodes and edges from `graphStore`
- update store on ReactFlow changes
- color nodes according to algorithm state
- expose `setNodes`, `setEdges` and `removeEdge` in the store

## Testing
- `bun run format`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_687ca6a8bf1c832587da8e5c41912118