### PR TITLE
Add graph editor toolbar component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,13 @@
 import "./index.css";
 import GraphCanvas from "./components/GraphCanvas";
+import GraphEditorToolbar from "./components/GraphEditorToolbar";
 import { useGraphStore } from "./store/graphStore";
 
 export default function App() {
   console.log("render app");
-  const setEditMode = useGraphStore((s) => s.setEditMode);
-  const resetGraph = useGraphStore((s) => s.resetGraph);
   const startAutoRun = useGraphStore((s) => s.startAutoRun);
   const stopAutoRun = useGraphStore((s) => s.stopAutoRun);
   const autoRun = useGraphStore((s) => s.algoState?.autoRun ?? false);
-
-  const handleResetGraph = () => {
-    if (confirm("Voulez-vous vraiment effacer le graphe ?")) {
-      resetGraph();
-    }
-  };
 
   const handleAutoRunToggle = () => {
     if (autoRun) {
@@ -36,28 +29,7 @@ export default function App() {
         {/* Left Panel - Edition */}
         <aside className="w-[20em] border-r border-gray-300 p-4 space-y-4 bg-white">
           <h2 className="font-semibold text-lg">Édition du graphe</h2>
-          <button
-            className="w-full bg-blue-600 text-white px-4 py-2 rounded"
-            onClick={() => setEditMode("addNode")}
-          >
-            Ajouter un nœud
-          </button>
-          <button
-            className="w-full bg-blue-600 text-white px-4 py-2 rounded"
-            onClick={() => setEditMode("addEdgeStep1")}
-          >
-            Ajouter une arête
-          </button>
-          <button
-            className="w-full bg-red-600 text-white px-4 py-2 rounded"
-            onClick={handleResetGraph}
-          >
-            Effacer graphe
-          </button>
-          <p className="text-sm text-gray-600 mt-6">
-            Cliquez sur le canvas pour placer un nœud après avoir cliqué sur
-            "Ajouter un nœud".
-          </p>
+          <GraphEditorToolbar />
         </aside>
 
         {/* Center Panel - Graph */}

--- a/src/components/GraphEditorToolbar.tsx
+++ b/src/components/GraphEditorToolbar.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useGraphStore } from "../store/graphStore";
+
+export default function GraphEditorToolbar() {
+  const editMode = useGraphStore((s) => s.editMode);
+  const setEditMode = useGraphStore((s) => s.setEditMode);
+  const resetGraph = useGraphStore((s) => s.resetGraph);
+  const editable = useGraphStore((s) => s.editable);
+
+  const handleResetGraph = () => {
+    if (confirm("Voulez-vous vraiment effacer le graphe ?")) {
+      resetGraph();
+    }
+  };
+
+  const instruction = (() => {
+    switch (editMode) {
+      case "addNode":
+        return "Cliquez dans le graphe pour placer le n\u0153ud";
+      case "addEdgeStep1":
+        return "Cliquez sur le n\u0153ud source";
+      case "addEdgeStep2":
+        return "Cliquez sur le n\u0153ud cible";
+      default:
+        return null;
+    }
+  })();
+
+  return (
+    <div className="space-y-4">
+      <button
+        className="w-full bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        onClick={() => setEditMode("addNode")}
+        disabled={!editable}
+      >
+        Ajouter un n\u0153ud
+      </button>
+      <button
+        className="w-full bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        onClick={() => setEditMode("addEdgeStep1")}
+        disabled={!editable}
+      >
+        Ajouter une ar\u00eate
+      </button>
+      <button
+        className="w-full bg-red-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        onClick={handleResetGraph}
+        disabled={!editable}
+      >
+        Effacer graphe
+      </button>
+      {instruction && <p className="text-sm text-gray-600">{instruction}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `GraphEditorToolbar` for basic edit actions
- show instructions depending on edit mode
- use toolbar in `App` layout

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cae66bd6c8325a051d1ae7d2cfb1f