### PR TITLE
Add algorithm control panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,10 @@
 import "./index.css";
 import GraphCanvas from "./components/GraphCanvas";
 import GraphEditorToolbar from "./components/GraphEditorToolbar";
-import { useGraphStore } from "./store/graphStore";
+import ControlPanel from "./components/ControlPanel";
 
 export default function App() {
   console.log("render app");
-  const startAutoRun = useGraphStore((s) => s.startAutoRun);
-  const stopAutoRun = useGraphStore((s) => s.stopAutoRun);
-  const autoRun = useGraphStore((s) => s.algoState?.autoRun ?? false);
-
-  const handleAutoRunToggle = () => {
-    if (autoRun) {
-      stopAutoRun();
-    } else {
-      startAutoRun();
-    }
-  };
 
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 text-gray-800">
@@ -40,39 +29,7 @@ export default function App() {
         {/* Right Panel - Algorithm Control */}
         <aside className="w-[20em] border-l border-gray-300 p-4 space-y-4 bg-white">
           <h2 className="font-semibold text-lg">Contrôle de l’algorithme</h2>
-          <button className="w-full bg-green-600 text-white px-4 py-2 rounded">
-            Démarrer
-          </button>
-          <button className="w-full bg-blue-500 text-white px-4 py-2 rounded">
-            Étape suivante
-          </button>
-          <button className="w-full bg-blue-500 text-white px-4 py-2 rounded">
-            Étape précédente
-          </button>
-          <button
-            className="w-full px-4 py-2 rounded text-white "
-            style={{ backgroundColor: autoRun ? "#DC2626" : "#6B7280" }}
-            onClick={handleAutoRunToggle}
-          >
-            {autoRun ? "Stop lecture automatique" : "Lecture automatique"}
-          </button>
-          <button className="w-full bg-yellow-500 text-white px-4 py-2 rounded">
-            Mode debug
-          </button>
-
-          <div className="mt-6">
-            <h3 className="text-md font-semibold">État de l’algo</h3>
-            <p className="text-sm text-gray-600 mt-2">Index / Lowlink :</p>
-            <ul className="text-sm list-disc list-inside">
-              <li>N1 : index = 0, lowlink = 0</li>
-              <li>N2 : index = 1, lowlink = 0</li>
-            </ul>
-            <p className="text-sm text-gray-600 mt-4">Pile :</p>
-            <div className="bg-gray-200 p-2 rounded">
-              <div className="bg-blue-200 p-1 my-1 rounded text-center">N2</div>
-              <div className="bg-blue-200 p-1 my-1 rounded text-center">N1</div>
-            </div>
-          </div>
+          <ControlPanel />
         </aside>
       </main>
 

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from "react";
+import { useAlgoStore } from "../store/algoState";
+import { useGraphStore } from "../store/graphStore";
+
+export default function ControlPanel() {
+  const status = useAlgoStore((s) => s.status);
+  const currentStep = useAlgoStore((s) => s.currentStep);
+  const startAlgo = useAlgoStore((s) => s.startAlgo);
+  const stepForward = useAlgoStore((s) => s.stepForward);
+  const stepBack = useAlgoStore((s) => s.stepBack);
+  const setEditable = useGraphStore((s) => s.setEditable);
+
+  const [autoRun, setAutoRun] = useState(false);
+  const [debugMode, setDebugMode] = useState(false);
+  const [showTheory, setShowTheory] = useState(false);
+
+  useEffect(() => {
+    if (!autoRun) return;
+    const id = window.setInterval(() => {
+      if (useAlgoStore.getState().status === "running") {
+        useAlgoStore.getState().stepForward();
+      } else {
+        setAutoRun(false);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [autoRun]);
+
+  const handleStart = () => {
+    startAlgo();
+    setEditable(false);
+  };
+
+  const handleStepForward = () => stepForward();
+  const handleStepBack = () => stepBack();
+  const handleToggleAutoRun = () => setAutoRun((v) => !v);
+  const handleToggleDebug = () => setDebugMode((v) => !v);
+  const handleToggleTheory = () => setShowTheory((v) => !v);
+
+  const startHidden = status !== "idle";
+  const forwardHidden = status !== "running";
+  const backHidden = status === "idle" || currentStep === 0;
+  const autoRunHidden = status !== "running";
+  const debugHidden = status === "idle";
+  const theoryHidden = status === "idle";
+
+  return (
+    <div className="space-y-4">
+      <button
+        className={`w-full bg-green-600 text-white px-4 py-2 rounded ${
+          startHidden ? "invisible" : ""
+        }`}
+        onClick={handleStart}
+        disabled={startHidden}
+      >
+        Démarrer l’algorithme
+      </button>
+      <button
+        className={`w-full bg-blue-500 text-white px-4 py-2 rounded ${
+          forwardHidden ? "invisible" : ""
+        }`}
+        onClick={handleStepForward}
+        disabled={forwardHidden}
+      >
+        Étape suivante
+      </button>
+      <button
+        className={`w-full bg-blue-500 text-white px-4 py-2 rounded ${
+          backHidden ? "invisible" : ""
+        }`}
+        onClick={handleStepBack}
+        disabled={backHidden}
+      >
+        Étape précédente
+      </button>
+      <button
+        className={`w-full px-4 py-2 rounded text-white ${
+          autoRunHidden ? "invisible" : ""
+        }`}
+        style={{ backgroundColor: autoRun ? "#DC2626" : "#6B7280" }}
+        onClick={handleToggleAutoRun}
+        disabled={autoRunHidden}
+      >
+        {autoRun ? "Stop lecture automatique" : "Lecture automatique"}
+      </button>
+      <button
+        className={`w-full bg-yellow-500 text-white px-4 py-2 rounded ${
+          debugHidden ? "invisible" : ""
+        }`}
+        onClick={handleToggleDebug}
+        disabled={debugHidden}
+      >
+        {debugMode ? "Quitter debug" : "Mode debug"}
+      </button>
+      <button
+        className={`w-full bg-purple-500 text-white px-4 py-2 rounded ${
+          theoryHidden ? "invisible" : ""
+        }`}
+        onClick={handleToggleTheory}
+        disabled={theoryHidden}
+      >
+        {showTheory ? "Masquer théorie" : "Voir théorie"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ControlPanel` with start/step/autorun/debug/theory buttons
- wire component in `App` instead of placeholder buttons

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cb91faf4c8325a0c48a3a2d0d5273