### PR TITLE
Add algorithm console display

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import "./index.css";
 import GraphCanvas from "./components/GraphCanvas";
 import GraphEditorToolbar from "./components/GraphEditorToolbar";
 import ControlPanel from "./components/ControlPanel";
+import AlgorithmConsole from "./components/AlgorithmConsole";
 
 export default function App() {
   console.log("render app");
@@ -30,6 +31,7 @@ export default function App() {
         <aside className="w-[20em] border-l border-gray-300 p-4 space-y-4 bg-white">
           <h2 className="font-semibold text-lg">Contrôle de l’algorithme</h2>
           <ControlPanel />
+          <AlgorithmConsole />
         </aside>
       </main>
 

--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { useAlgoStore } from "../store/algoState";
+
+export default function AlgorithmConsole() {
+  const { indexMap, lowLinkMap, stack } = useAlgoStore((s) => ({
+    indexMap: s.indexMap,
+    lowLinkMap: s.lowLinkMap,
+    stack: s.stack,
+  }));
+
+  const rows = Array.from(indexMap.keys()).map((id) => ({
+    id,
+    index: indexMap.get(id) ?? "",
+    lowlink: lowLinkMap.get(id) ?? "",
+  }));
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="font-semibold">Index / Lowlink</h3>
+        <table className="w-full text-left border border-gray-300">
+          <thead className="bg-gray-200">
+            <tr>
+              <th className="px-2 py-1 border border-gray-300">Nœud</th>
+              <th className="px-2 py-1 border border-gray-300">Index</th>
+              <th className="px-2 py-1 border border-gray-300">Lowlink</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.id} className="odd:bg-white even:bg-gray-50">
+                <td className="px-2 py-1 border border-gray-300">{r.id}</td>
+                <td className="px-2 py-1 border border-gray-300">{r.index}</td>
+                <td className="px-2 py-1 border border-gray-300">
+                  {r.lowlink}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <h3 className="font-semibold">Pile</h3>
+        <ul className="border border-gray-300 bg-gray-50 divide-y divide-gray-300">
+          {stack.map((id) => (
+            <li key={id} className="px-2 py-1">
+              {id}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -1,17 +1,22 @@
 import React from "react";
 import { useAlgoStore } from "../store/algoState";
+import { useGraphStore } from "../store/graphStore";
+import { useShallow } from "zustand/react/shallow";
 
 export default function AlgorithmConsole() {
-  const { indexMap, lowLinkMap, stack } = useAlgoStore((s) => ({
-    indexMap: s.indexMap,
-    lowLinkMap: s.lowLinkMap,
-    stack: s.stack,
-  }));
+  const { indexMap, lowLinkMap, stack } = useAlgoStore(
+    useShallow((s) => ({
+      indexMap: s.indexMap,
+      lowLinkMap: s.lowLinkMap,
+      stack: s.stack,
+    })),
+  );
+  const nodes = useGraphStore((s) => s.nodes);
 
-  const rows = Array.from(indexMap.keys()).map((id) => ({
-    id,
-    index: indexMap.get(id) ?? "",
-    lowlink: lowLinkMap.get(id) ?? "",
+  const rows = nodes.map((n) => ({
+    id: n.id,
+    index: indexMap.get(n.id) ?? "—",
+    lowlink: lowLinkMap.get(n.id) ?? "—",
   }));
 
   return (


### PR DESCRIPTION
## Summary
- display algorithm state with new `AlgorithmConsole` component
- show index/lowlink tables and stack
- render this console in the right panel

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_687cc81e60a4832595f5d09a97656aa9