### PR TITLE
Add debug call tree view

### DIFF
--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
+import DebugCallTree from "./DebugCallTree";
 
 export default function ControlPanel() {
   const status = useAlgoStore((s) => s.status);
@@ -101,6 +102,7 @@ export default function ControlPanel() {
       >
         {showTheory ? "Masquer théorie" : "Voir théorie"}
       </button>
+      {debugMode && <DebugCallTree />}
     </div>
   );
 }

--- a/src/components/DebugCallTree.tsx
+++ b/src/components/DebugCallTree.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useAlgoStore } from "../store/algoState";
+
+export default function DebugCallTree() {
+  const callStack = useAlgoStore((s) => s.callStack);
+
+  if (callStack.length === 0) {
+    return (
+      <div className="p-2 bg-white rounded shadow">
+        <p className="italic text-gray-500">Aucun appel en cours.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-2 bg-white rounded shadow font-mono text-sm">
+      <ul>
+        {callStack.map((id, idx) => (
+          <li key={idx} style={{ paddingLeft: `${idx * 1.5}rem` }}>
+            {id}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ExplanationBox.tsx
+++ b/src/components/ExplanationBox.tsx
@@ -20,6 +20,10 @@ export default function ExplanationBox({ update }: ExplanationBoxProps) {
         return `Détection d\u2019une composante depuis ${currentNode}.`;
       case "skip":
         return `Ar\u00eate vers ${currentNode} ignor\u00e9e.`;
+      case "enter":
+        return `Appel de strongConnect(${currentNode}).`;
+      case "return":
+        return `Retour de strongConnect(${currentNode}).`;
       default:
         return null;
     }

--- a/src/store/algoState.ts
+++ b/src/store/algoState.ts
@@ -11,6 +11,7 @@ export interface AlgoState {
   lowLinkMap: Map<NodeId, number>;
   onStackMap: Map<NodeId, boolean>;
   stack: NodeId[];
+  callStack: NodeId[];
   sccs: NodeId[][];
   currentIndex: number;
   currentStep: number;
@@ -31,6 +32,7 @@ const initialState: AlgoState = {
   lowLinkMap: new Map(),
   onStackMap: new Map(),
   stack: [],
+  callStack: [],
   sccs: [],
   currentIndex: 0,
   currentStep: 0,
@@ -73,6 +75,7 @@ export const useAlgoStore = create<AlgoStore>((set) => ({
         lowLinkMap: update.lowLinkMap,
         onStackMap: update.onStackMap,
         stack: update.stack,
+        callStack: update.callStack,
         sccs: update.sccs,
         currentIndex: update.indexMap.size,
         currentStep: state.currentStep + 1,

--- a/src/utils/tarjan.ts
+++ b/src/utils/tarjan.ts
@@ -4,9 +4,17 @@ export type Graph = {
 };
 
 export interface TarjanStateUpdate {
-  action: "visit" | "push" | "set-lowlink" | "pop-scc" | "skip";
+  action:
+    | "visit"
+    | "push"
+    | "set-lowlink"
+    | "pop-scc"
+    | "skip"
+    | "enter"
+    | "return";
   currentNode: string;
   stack: string[];
+  callStack: string[];
   indexMap: Map<string, number>;
   lowLinkMap: Map<string, number>;
   onStackMap: Map<string, boolean>;
@@ -18,6 +26,7 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
   const lowLinkMap = new Map<string, number>();
   const onStackMap = new Map<string, boolean>();
   const stack: string[] = [];
+  const callStack: string[] = [];
   const sccs: string[][] = [];
   let index = 0;
 
@@ -38,6 +47,7 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
       action,
       currentNode,
       stack: [...stack],
+      callStack: [...callStack],
       indexMap: new Map(indexMap),
       lowLinkMap: new Map(lowLinkMap),
       onStackMap: new Map(onStackMap),
@@ -46,6 +56,8 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
   }
 
   function* strongConnect(v: string): Generator<TarjanStateUpdate> {
+    callStack.push(v);
+    yield snapshot("enter", v);
     indexMap.set(v, index);
     lowLinkMap.set(v, index);
     index += 1;
@@ -82,6 +94,8 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
       sccs.push(component);
       yield snapshot("pop-scc", v);
     }
+    callStack.pop();
+    yield snapshot("return", v);
   }
 
   for (const node of graph.nodes) {


### PR DESCRIPTION
## Summary
- implement `DebugCallTree` component rendering current recursion stack
- wire debug button in `ControlPanel` to toggle the call tree
- keep track of `callStack` in algo state
- update Tarjan generator and ExplanationBox for new actions

## Testing
- `bun run format`
- `bun run lint`


------
https://chatgpt.com/codex/tasks/task_e_687f5774ada08325916244fe2d4241ae