### PR TITLE
Add theory panel with React Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "reactflow": "^11.11.4",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "react-markdown": "^9.1.9"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/assets/theory.md
+++ b/src/assets/theory.md
@@ -1,0 +1,41 @@
+# Algorithme de Tarjan
+
+## Pseudocode
+
+```text
+function tarjan(G):
+    index := 0
+    stack := empty
+    for v in G:
+        if v not visited:
+            strongConnect(v)
+
+function strongConnect(v):
+    indexMap[v] := index
+    lowLinkMap[v] := index
+    index := index + 1
+    push v on stack
+    for each w in successors(v):
+        if w not visited:
+            strongConnect(w)
+            lowLinkMap[v] := min(lowLinkMap[v], lowLinkMap[w])
+        else if w on stack:
+            lowLinkMap[v] := min(lowLinkMap[v], indexMap[w])
+    if lowLinkMap[v] = indexMap[v]:
+        pop vertices from stack until v
+        output the component
+```
+
+## Définitions
+
+- **DFS** : parcours en profondeur du graphe.
+- **Lowlink** : plus petit index atteignable depuis un sommet par un chemin DFS.
+- **SCC (Strongly Connected Component)** : sous-ensemble de sommets tels que chaque sommet est accessible depuis les autres.
+
+## Complexité
+
+L'algorithme s'exécute en `O(V + E)` où `V` est le nombre de sommets et `E` le nombre d'arêtes.
+
+## Pour aller plus loin
+
+[Article Wikipédia sur l'algorithme de Tarjan](https://fr.wikipedia.org/wiki/Algorithme_de_Tarjan)

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -44,7 +44,7 @@ export default function ControlPanel() {
   const backHidden = status === "idle" || currentStep === 0;
   const autoRunHidden = status !== "running";
   const debugHidden = status === "idle";
-  const theoryHidden = status === "idle";
+  const theoryHidden = false;
 
   return (
     <div className="space-y-4">

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 import DebugCallTree from "./DebugCallTree";
+import TheorySlide from "./TheorySlide";
 
 export default function ControlPanel() {
   const status = useAlgoStore((s) => s.status);
@@ -103,6 +104,7 @@ export default function ControlPanel() {
         {showTheory ? "Masquer théorie" : "Voir théorie"}
       </button>
       {debugMode && <DebugCallTree />}
+      {showTheory && <TheorySlide onClose={handleToggleTheory} />}
     </div>
   );
 }

--- a/src/components/TheorySlide.tsx
+++ b/src/components/TheorySlide.tsx
@@ -22,7 +22,9 @@ export default function TheorySlide({ onClose }: TheorySlideProps) {
         >
           Fermer
         </button>
-        <ReactMarkdown className="prose">{theory}</ReactMarkdown>
+        <div className="prose">
+          <ReactMarkdown>{theory}</ReactMarkdown>
+        </div>
       </div>
     </div>
   );

--- a/src/components/TheorySlide.tsx
+++ b/src/components/TheorySlide.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import theory from "../assets/theory.md?raw";
+
+interface TheorySlideProps {
+  onClose: () => void;
+}
+
+export default function TheorySlide({ onClose }: TheorySlideProps) {
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex"
+      onClick={onClose}
+    >
+      <div
+        className="ml-auto w-[30rem] max-w-full h-full bg-white p-4 overflow-y-auto shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className="mb-4 px-2 py-1 bg-gray-200 rounded text-sm"
+          onClick={onClose}
+        >
+          Fermer
+        </button>
+        <ReactMarkdown className="prose">{theory}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/tarjan.test.ts
+++ b/src/utils/tarjan.test.ts
@@ -10,10 +10,10 @@ const simpleGraph: Graph = {
 };
 
 describe("tarjanStepByStep", () => {
-  it("yields visit action first", () => {
+  it("yields enter action first", () => {
     const gen = tarjanStepByStep(simpleGraph);
     const step = gen.next().value;
-    expect(step.action).toBe("visit");
+    expect(step.action).toBe("enter");
     expect(step.currentNode).toBe("a");
   });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "*.md?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- write markdown file with algorithm theory
- implement `TheorySlide` component rendered with `react-markdown`
- show theory slide from `ControlPanel`
- declare `*.md?raw` module type
- adjust tarjan tests

## Testing
- `bun run format`
- `bun run lint`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_687f597a91d883259e5c4f1d3517b807