### PR TITLE
feat: add history store with step back support

### DIFF
--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import type { TarjanStateUpdate } from "../utils/tarjan";
+
+interface HistoryStore {
+  stack: TarjanStateUpdate[];
+  push: (update: TarjanStateUpdate) => void;
+  pop: () => TarjanStateUpdate | undefined;
+  last: () => TarjanStateUpdate | undefined;
+  reset: () => void;
+}
+
+export const useHistoryStore = create<HistoryStore>((set, get) => ({
+  stack: [],
+  push: (update) => set((s) => ({ stack: [...s.stack, update] })),
+  pop: () => {
+    let popped: TarjanStateUpdate | undefined;
+    set((s) => {
+      const copy = [...s.stack];
+      popped = copy.pop();
+      return { stack: copy };
+    });
+    return popped;
+  },
+  last: () => {
+    const { stack } = get();
+    return stack[stack.length - 1];
+  },
+  reset: () => set({ stack: [] }),
+}));


### PR DESCRIPTION
## Summary
- manage Tarjan state history in a zustand store
- push updates when stepping forward
- pop states on step back to restore previous algorithm state

## Testing
- `bun run format`
- `bun run lint`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_687fba2b7dec83258d0272a5f9cc84d6