### PR TITLE
Fix node drag misalignment

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -128,8 +128,11 @@ export default function GraphCanvas() {
       "drag",
       (event, d) => {
         if (!editable) return;
+        const bounds = svgEl.getBoundingClientRect();
+        const x = event.sourceEvent.clientX - bounds.left;
+        const y = event.sourceEvent.clientY - bounds.top;
         const updated = nodes.map((n) =>
-          n.id === d.id ? { ...n, position: { x: event.x, y: event.y } } : n,
+          n.id === d.id ? { ...n, position: { x, y } } : n,
         );
         setGraphNodes(
           updated.map((node) => {


### PR DESCRIPTION
## Summary
- fix node drag by using absolute mouse coordinates when updating position

## Testing
- `bun run format`
- `bun run lint`
- `bun run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6880d9b5300c832599b9da71a76e0202