### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: "latest"
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v1

--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 import { useShallow } from "zustand/react/shallow";

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 import DebugCallTree from "./DebugCallTree";

--- a/src/components/DebugCallTree.tsx
+++ b/src/components/DebugCallTree.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useAlgoStore } from "../store/algoState";
 
 export default function DebugCallTree() {

--- a/src/components/ExplanationBox.tsx
+++ b/src/components/ExplanationBox.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { useMemo } from "react";
 import type { TarjanStateUpdate } from "../utils/tarjan";
 
 interface ExplanationBoxProps {
@@ -6,7 +6,7 @@ interface ExplanationBoxProps {
 }
 
 export default function ExplanationBox({ update }: ExplanationBoxProps) {
-  const message = React.useMemo(() => {
+  const message = useMemo(() => {
     if (!update) return null;
     const { action, currentNode } = update;
     switch (action) {

--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -1,9 +1,19 @@
-import React, { useCallback, useEffect, useRef } from "react";
+import type React from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { select } from "d3-selection";
 import { drag as d3Drag } from "d3-drag";
-import { useGraphStore, type GraphNode } from "../store/graphStore";
+import {
+  useGraphStore,
+  type GraphNode,
+  type GraphEdge,
+} from "../store/graphStore";
 import { useAlgoStore } from "../store/algoState";
 import { useShallow } from "zustand/react/shallow";
+
+interface DragEventLike {
+  x: number;
+  y: number;
+}
 
 export default function GraphCanvas() {
   const nodes = useGraphStore((s) => s.nodes);
@@ -119,14 +129,14 @@ export default function GraphCanvas() {
       .join("line")
       .attr("stroke", "#666")
       .attr("marker-end", "url(#arrow)")
-      .attr("x1", (d) => nodeMap.get(d.from)?.position.x ?? 0)
-      .attr("y1", (d) => nodeMap.get(d.from)?.position.y ?? 0)
-      .attr("x2", (d) => nodeMap.get(d.to)?.position.x ?? 0)
-      .attr("y2", (d) => nodeMap.get(d.to)?.position.y ?? 0);
+      .attr("x1", (d: GraphEdge) => nodeMap.get(d.from)?.position.x ?? 0)
+      .attr("y1", (d: GraphEdge) => nodeMap.get(d.from)?.position.y ?? 0)
+      .attr("x2", (d: GraphEdge) => nodeMap.get(d.to)?.position.x ?? 0)
+      .attr("y2", (d: GraphEdge) => nodeMap.get(d.to)?.position.y ?? 0);
 
-    const dragBehaviour = d3Drag<SVGGElement, GraphNode>().on(
+    const dragBehaviour = d3Drag().on(
       "drag",
-      (event, d) => {
+      (event: DragEventLike, d: GraphNode) => {
         if (!editable) return;
         const updated = nodes.map((n) =>
           n.id === d.id ? { ...n, position: { x: event.x, y: event.y } } : n,
@@ -148,9 +158,12 @@ export default function GraphCanvas() {
       .data(nodes)
       .join("g")
       .attr("class", "node")
-      .attr("transform", (d) => `translate(${d.position.x},${d.position.y})`)
+      .attr(
+        "transform",
+        (d: GraphNode) => `translate(${d.position.x},${d.position.y})`,
+      )
       .call(dragBehaviour)
-      .on("click", (event, d) => {
+      .on("click", (event: React.MouseEvent<SVGGElement>, d: GraphNode) => {
         event.stopPropagation();
         handleNodeClick(d.id);
       });
@@ -158,13 +171,13 @@ export default function GraphCanvas() {
     nodeGroups
       .append("circle")
       .attr("r", 20)
-      .attr("class", (d) => getNodeClass(d));
+      .attr("class", (d: GraphNode) => getNodeClass(d));
 
     nodeGroups
       .append("text")
       .attr("text-anchor", "middle")
       .attr("dy", ".35em")
-      .text((d) => d.label);
+      .text((d: GraphNode) => d.label);
   }, [nodes, edges, editable, getNodeClass, handleNodeClick, setGraphNodes]);
 
   return (

--- a/src/components/TheorySlide.tsx
+++ b/src/components/TheorySlide.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ReactMarkdown from "react-markdown";
 import theory from "../assets/theory.md?raw";
 

--- a/src/types/bun-test.d.ts
+++ b/src/types/bun-test.d.ts
@@ -1,0 +1,1 @@
+declare module "bun:test";

--- a/src/types/d3-modules.d.ts
+++ b/src/types/d3-modules.d.ts
@@ -1,0 +1,2 @@
+declare module "d3-selection";
+declare module "d3-drag";

--- a/src/utils/tarjan.test.ts
+++ b/src/utils/tarjan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
-import { tarjanStepByStep, Graph } from "./tarjan";
+import { tarjanStepByStep } from "./tarjan";
+import type { Graph } from "./tarjan";
 
 const simpleGraph: Graph = {
   nodes: [{ id: "a" }, { id: "b" }],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "./",
   plugins: [tailwindcss(), react()],
 });


### PR DESCRIPTION
## Summary
- add workflow to deploy the build output on GitHub Pages
- set Vite `base` path to relative paths
- fix TypeScript errors for build and lint

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6880da0eb8ac8325a63602099d39cda3