### PR TITLE
feat: toolbar icons & no CDN

### DIFF
--- a/context/specs-techniques.md
+++ b/context/specs-techniques.md
@@ -132,5 +132,7 @@ interface TarjanStateUpdate {
 - Graphe limité en taille (~30 nœuds)
 - Animations non bloquantes
 - Aucune dépendance critique instable
+- Les librairies externes ne doivent jamais être chargées via CDN, elles sont
+  installées localement
 
 ---

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-markdown": "^10.1.0",
     "zustand": "^5.0.6",
     "d3-drag": "^3.0.0",
-    "d3-selection": "^3.0.0"
+    "d3-selection": "^3.0.0",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,36 +10,30 @@ export default function App() {
   console.log("render app");
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50 text-gray-800">
+    <div className="flex min-h-screen flex-col bg-gray-50 text-gray-800">
       {/* Header */}
-      <header className="bg-white shadow p-4 text-center text-2xl font-bold">
+      <header className="bg-white p-4 text-center text-2xl font-bold shadow">
         Trajan Algo
       </header>
 
       {/* Main layout */}
       <main className="flex flex-1 overflow-hidden">
-        {/* Left Panel - Edition */}
-        <aside className="w-[20em] border-r border-gray-300 p-4 space-y-4 bg-white">
-          <h2 className="font-semibold text-lg">Édition du graphe</h2>
+        <section className="flex-grow space-y-4 bg-gray-100 p-4">
           <GraphEditorToolbar />
-        </aside>
-
-        {/* Center Panel - Graph */}
-        <section className="flex-grow p-4 space-y-4 bg-gray-100">
           <GraphCanvas />
           <ExplanationBox update={useAlgoStore((s) => s.lastUpdate)} />
         </section>
 
         {/* Right Panel - Algorithm Control */}
-        <aside className="w-[20em] border-l border-gray-300 p-4 space-y-4 bg-white">
-          <h2 className="font-semibold text-lg">Contrôle de l’algorithme</h2>
+        <aside className="w-[20em] space-y-4 border-l border-gray-300 bg-white p-4">
+          <h2 className="text-lg font-semibold">Contrôle de l’algorithme</h2>
           <ControlPanel />
           <AlgorithmConsole />
         </aside>
       </main>
 
       {/* Footer */}
-      <footer className="bg-white text-center text-sm text-gray-500 py-2 shadow-inner">
+      <footer className="bg-white py-2 text-center text-sm text-gray-500 shadow-inner">
         JLG Formation ©2025
       </footer>
     </div>

--- a/src/components/GraphEditorToolbar.tsx
+++ b/src/components/GraphEditorToolbar.tsx
@@ -1,3 +1,4 @@
+import { FaLink, FaTrash, FaTrashAlt } from "react-icons/fa";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 
@@ -35,33 +36,38 @@ export default function GraphEditorToolbar() {
   })();
 
   return (
-    <div className="space-y-4">
+    <div className="flex items-center gap-2">
       <button
-        className="w-full bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
         onClick={() => {
           if (confirmAlgoReset()) setEditMode("addEdgeStep1");
         }}
         disabled={!editable}
+        aria-label="Ajouter une arête"
       >
-        Ajouter une arête
+        <FaLink className="h-5 w-5" />
       </button>
       {selectedNodes.length > 0 && (
         <button
-          className="w-full bg-red-600 text-white px-4 py-2 rounded disabled:opacity-50"
+          className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
           onClick={removeSelectedNodes}
           disabled={!editable}
+          aria-label="Effacer le nœud"
         >
-          Effacer le nœud
+          <FaTrash className="h-5 w-5" />
         </button>
       )}
       <button
-        className="w-full bg-red-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
         onClick={handleResetGraph}
         disabled={!editable}
+        aria-label="Effacer graphe"
       >
-        Effacer graphe
+        <FaTrashAlt className="h-5 w-5" />
       </button>
-      {instruction && <p className="text-sm text-gray-600">{instruction}</p>}
+      {instruction && (
+        <p className="ml-2 text-sm text-gray-600">{instruction}</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- forbid CDN libraries in technical specs
- use `react-icons` icons in `GraphEditorToolbar`
- remove FontAwesome CDN link
- declare `react-icons` dependency

## Testing
- `bun run format`
- `bun run lint`
- `bun run build` *(fails: Cannot find module 'react-icons/fa')*
- `bun install` *(fails: 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_6880ea1949f88325b36643ad0a19b35c