### PR TITLE
Ajout de la mise en surbrillance lors de l'ajout d'arête

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -46,11 +46,16 @@ export default function GraphCanvas() {
   const selectedNodes = useGraphStore((s) => s.selectedNodes);
   const toggleNodeSelection = useGraphStore((s) => s.toggleNodeSelection);
   const getNodeClass = useCallback(
-    (n: GraphNode) =>
-      selectedNodes.includes(n.id)
+    (n: GraphNode) => {
+      // highlight the temporary source node in yellow when building an edge
+      if (selectedNodeForEdge === n.id) {
+        return `${baseClass} fill-yellow-300`;
+      }
+      return selectedNodes.includes(n.id)
         ? `${baseClass} fill-gray-300`
-        : `${baseClass} fill-white`,
-    [selectedNodes],
+        : `${baseClass} fill-white`;
+    },
+    [selectedNodes, selectedNodeForEdge],
   );
 
   const svgRef = useRef<SVGSVGElement | null>(null);

--- a/src/components/GraphEditorToolbar.tsx
+++ b/src/components/GraphEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { FaLink, FaTrash, FaTrashAlt } from "react-icons/fa";
+import { FaLink, FaTimes, FaTrash, FaTrashAlt } from "react-icons/fa";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 
@@ -6,6 +6,7 @@ export default function GraphEditorToolbar() {
   const status = useAlgoStore((s) => s.status);
   const editMode = useGraphStore((s) => s.editMode);
   const setEditMode = useGraphStore((s) => s.setEditMode);
+  const setSelectedNodeForEdge = useGraphStore((s) => s.setSelectedNodeForEdge);
   const resetGraph = useGraphStore((s) => s.resetGraph);
   const editable = useGraphStore((s) => s.editable);
   const selectedNodes = useGraphStore((s) => s.selectedNodes);
@@ -35,17 +36,29 @@ export default function GraphEditorToolbar() {
     }
   })();
 
+  // when true, the toolbar shows a cancel icon and the selected source is cleared
+  const isAddingEdge = editMode === "addEdgeStep1" || editMode === "addEdgeStep2";
+
   return (
     <div className="flex items-center gap-2">
       <button
         className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
         onClick={() => {
-          if (confirmAlgoReset()) setEditMode("addEdgeStep1");
+          if (isAddingEdge) {
+            setSelectedNodeForEdge(null);
+            setEditMode("none");
+          } else if (confirmAlgoReset()) {
+            setEditMode("addEdgeStep1");
+          }
         }}
         disabled={!editable}
-        aria-label="Ajouter une arête"
+        aria-label={isAddingEdge ? "Annuler l'ajout" : "Ajouter une arête"}
       >
-        <FaLink className="h-5 w-5" />
+        {isAddingEdge ? (
+          <FaTimes className="h-5 w-5" />
+        ) : (
+          <FaLink className="h-5 w-5" />
+        )}
       </button>
       {selectedNodes.length > 0 && (
         <button


### PR DESCRIPTION
## Summary
- highlight temporary source node in yellow during edge creation
- allow cancelling edge creation from the toolbar

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6880ee8b0fb48325a297abbb030c0dbb