### PR TITLE
feat: pointer/grab cursor for nodes

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -179,9 +179,8 @@ export default function GraphCanvas() {
 
     const dragBehaviour = d3Drag()
       .on("start", function (this: SVGGElement) {
-        select(this)
-          .classed("cursor-pointer", false)
-          .classed("cursor-grab", true);
+        select(this).classed("cursor-pointer", false);
+        select(svgEl).classed("cursor-grabbing", true);
       })
       .on("drag", (event: DragEventLike, d: GraphNode) => {
         if (!editable) return;
@@ -200,9 +199,8 @@ export default function GraphCanvas() {
         );
       })
       .on("end", function (this: SVGGElement) {
-        select(this)
-          .classed("cursor-grab", false)
-          .classed("cursor-pointer", true);
+        select(svgEl).classed("cursor-grabbing", false);
+        select(this).classed("cursor-pointer", true);
       });
 
     const nodeGroups = svg


### PR DESCRIPTION
## Summary
- change GraphCanvas drag behavior to show grab cursor while dragging
- add pointer cursor when hovering nodes

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_688103297db08325926b5eceb2c2268d