### PR TITLE
Update GraphEditorToolbar layout

### DIFF
--- a/src/components/GraphEditorToolbar.tsx
+++ b/src/components/GraphEditorToolbar.tsx
@@ -1,4 +1,4 @@
-import { FaLink, FaTimes, FaTrash, FaTrashAlt } from "react-icons/fa";
+import { FaLink, FaTimes, FaTrash } from "react-icons/fa";
 import { useAlgoStore } from "../store/algoState";
 import { useGraphStore } from "../store/graphStore";
 
@@ -37,50 +37,53 @@ export default function GraphEditorToolbar() {
   })();
 
   // when true, the toolbar shows a cancel icon and the selected source is cleared
-  const isAddingEdge = editMode === "addEdgeStep1" || editMode === "addEdgeStep2";
+  const isAddingEdge =
+    editMode === "addEdgeStep1" || editMode === "addEdgeStep2";
 
   return (
-    <div className="flex items-center gap-2">
-      <button
-        className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
-        onClick={() => {
-          if (isAddingEdge) {
-            setSelectedNodeForEdge(null);
-            setEditMode("none");
-          } else if (confirmAlgoReset()) {
-            setEditMode("addEdgeStep1");
-          }
-        }}
-        disabled={!editable}
-        aria-label={isAddingEdge ? "Annuler l'ajout" : "Ajouter une arête"}
-      >
-        {isAddingEdge ? (
-          <FaTimes className="h-5 w-5" />
-        ) : (
-          <FaLink className="h-5 w-5" />
-        )}
-      </button>
-      {selectedNodes.length > 0 && (
+    <div className="flex w-full items-center justify-between">
+      <div className="flex items-center gap-2">
         <button
           className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
-          onClick={removeSelectedNodes}
+          onClick={() => {
+            if (isAddingEdge) {
+              setSelectedNodeForEdge(null);
+              setEditMode("none");
+            } else if (confirmAlgoReset()) {
+              setEditMode("addEdgeStep1");
+            }
+          }}
           disabled={!editable}
-          aria-label="Effacer le nœud"
+          aria-label={isAddingEdge ? "Annuler l'ajout" : "Ajouter une arête"}
         >
-          <FaTrash className="h-5 w-5" />
+          {isAddingEdge ? (
+            <FaTimes className="h-5 w-5" />
+          ) : (
+            <FaLink className="h-5 w-5" />
+          )}
         </button>
-      )}
+        {selectedNodes.length > 0 && (
+          <button
+            className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
+            onClick={removeSelectedNodes}
+            disabled={!editable}
+            aria-label="Effacer le nœud"
+          >
+            <FaTrash className="h-5 w-5" />
+          </button>
+        )}
+        {instruction && (
+          <p className="ml-2 text-sm text-gray-600">{instruction}</p>
+        )}
+      </div>
       <button
-        className="cursor-pointer rounded bg-gray-500 p-2 text-white disabled:opacity-50"
+        className="cursor-pointer rounded bg-gray-500 px-4 py-2 text-white disabled:opacity-50"
         onClick={handleResetGraph}
         disabled={!editable}
-        aria-label="Effacer graphe"
+        aria-label="Nouveau graphe"
       >
-        <FaTrashAlt className="h-5 w-5" />
+        Nouveau graphe
       </button>
-      {instruction && (
-        <p className="ml-2 text-sm text-gray-600">{instruction}</p>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update GraphEditorToolbar so it spans full width
- move the 'reset graph' button to the right and rename it "Nouveau graphe"

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6881033c4d2483258631ca1eaad9395e