### PR TITLE
feat: add cursor state to GraphCanvas

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -203,7 +203,7 @@ export default function GraphCanvas() {
         );
       })
       .on("end", () => {
-        setCursor("cursor-pointer");
+        setCursor("");
       });
 
     const nodeGroups = svg
@@ -218,8 +218,14 @@ export default function GraphCanvas() {
         (d: GraphNode) => `translate(${d.position.x},${d.position.y})`,
       )
       .call(dragBehaviour)
-      .on("mouseenter", () => setCursor("cursor-pointer"))
-      .on("mouseleave", () => setCursor(""))
+      .on("mouseenter", () => {
+        if (cursor === "") {
+          setCursor("cursor-pointer");
+        }
+      })
+      .on("mouseleave", () => {
+        setCursor("");
+      })
       .on("click", (event: React.MouseEvent<SVGGElement>, d: GraphNode) => {
         event.stopPropagation();
         handleNodeClick(d.id);
@@ -235,7 +241,15 @@ export default function GraphCanvas() {
       .attr("text-anchor", "middle")
       .attr("dy", ".35em")
       .text((d: GraphNode) => d.label);
-  }, [nodes, edges, editable, getNodeClass, handleNodeClick, setGraphNodes]);
+  }, [
+    nodes,
+    edges,
+    editable,
+    getNodeClass,
+    handleNodeClick,
+    setGraphNodes,
+    cursor,
+  ]);
 
   return (
     <svg


### PR DESCRIPTION
## Summary
- track mouse cursor state within `GraphCanvas`
- update SVG classes while hovering or dragging nodes

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`

------
https://chatgpt.com/codex/tasks/task_e_68811021313c8325ae430a03766c8cdf