### PR TITLE
fix: compute unique node labels

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -7,6 +7,7 @@ import {
   type GraphNode,
   type GraphEdge,
 } from "../store/graphStore";
+import { getNextNodeLabel } from "../utils/graphHelpers";
 import { useAlgoStore } from "../store/algoState";
 import { useShallow } from "zustand/react/shallow";
 
@@ -102,11 +103,11 @@ export default function GraphCanvas() {
       const y = event.clientY - bounds.top;
       addGraphNode({
         id: getNextNodeId(),
-        label: `N${nodes.length + 1}`,
+        label: getNextNodeLabel(nodes),
         position: { x, y },
       });
     },
-    [editable, editMode, getNextNodeId, addGraphNode, nodes.length],
+    [editable, editMode, getNextNodeId, addGraphNode, nodes],
   );
 
   useEffect(() => {

--- a/src/utils/graphHelpers.ts
+++ b/src/utils/graphHelpers.ts
@@ -1,0 +1,23 @@
+export interface LabeledNode {
+  label: string;
+}
+
+/**
+ * Return a label "N<number>" filling gaps in existing nodes labels.
+ * If numbers 1..n contain holes, the smallest missing number is used.
+ * Otherwise returns N<nodes.length + 1>.
+ */
+export function getNextNodeLabel(nodes: LabeledNode[]): string {
+  const used = new Set<number>();
+  for (const n of nodes) {
+    const match = /^N(\d+)$/.exec(n.label);
+    if (match) {
+      used.add(Number(match[1]));
+    }
+  }
+  let i = 1;
+  while (used.has(i)) {
+    i++;
+  }
+  return `N${i}`;
+}


### PR DESCRIPTION
## Summary
- ensure new nodes fill gaps in numbering
- add helper `getNextNodeLabel`

## Testing
- `bun run format`
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68811c450b1883258e70bafe7cba934f