### PR TITLE
Implement slide animation for theory overlay

### DIFF
--- a/src/components/TheorySlide.tsx
+++ b/src/components/TheorySlide.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import theory from "../assets/theory.md?raw";
 
@@ -6,18 +7,29 @@ interface TheorySlideProps {
 }
 
 export default function TheorySlide({ onClose }: TheorySlideProps) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+  }, []);
+
+  const handleClose = () => {
+    setVisible(false);
+    setTimeout(onClose, 300);
+  };
+
   return (
     <div
-      className="fixed inset-0 bg-black bg-opacity-50 flex"
-      onClick={onClose}
+      className={`bg-opacity-40 fixed inset-0 flex bg-black transition-opacity duration-300 ${visible ? "opacity-100" : "opacity-0"}`}
+      onClick={handleClose}
     >
       <div
-        className="ml-auto w-[30rem] max-w-full h-full bg-white p-4 overflow-y-auto shadow-lg"
+        className={`h-full w-[30rem] max-w-full overflow-y-auto bg-white p-4 shadow-lg transition-transform duration-300 ${visible ? "translate-x-0" : "-translate-x-full"}`}
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          className="mb-4 px-2 py-1 bg-gray-200 rounded text-sm"
-          onClick={onClose}
+          className="mb-4 rounded bg-gray-200 px-2 py-1 text-sm"
+          onClick={handleClose}
         >
           Fermer
         </button>


### PR DESCRIPTION
## Summary
- animate TheorySlide with CSS transitions
- close the panel when clicking outside

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68811cf29e38832580ac9143d6d69340