### PR TITLE
Ensure pointer cursor on all buttons

### DIFF
--- a/context/specs-ui-maquette.md
+++ b/context/specs-ui-maquette.md
@@ -71,12 +71,14 @@ Fixe en bas de la page :
   - Non visité, Visite en cours, Dans la pile, SCC trouvée
 - Une couleur différente par SCC détectée
 - Layout **non responsive**, prévu pour écran desktop ≥ 1280px
-- Utilisation de Tailwind pour les espacements, flex layout et invisibilité conditionnelle
+- Utilisation de Tailwind pour les espacements, flex layout et invisibilité
+  conditionnelle
 
 ## Règles UI
 
-- tailwindcss: tous les boutons doivent avoir cursor-pointer
-- utiliser une librairie d'icone (react-icons with fa)
+- Tous les boutons doivent afficher le curseur en forme de main via la classe
+  `cursor-pointer` de TailwindCSS
+- Utiliser une librairie d'icone (react-icons with fa)
 
 ---
 

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -56,13 +56,13 @@ export default function ControlPanel() {
   return (
     <div className="space-y-4">
       <button
-        className="w-full rounded bg-green-600 px-4 py-2 text-white"
+        className="w-full cursor-pointer rounded bg-green-600 px-4 py-2 text-white"
         onClick={handleStartClick}
       >
         {startLabel}
       </button>
       <button
-        className={`w-full rounded bg-blue-500 px-4 py-2 text-white ${
+        className={`w-full cursor-pointer rounded bg-blue-500 px-4 py-2 text-white ${
           forwardHidden ? "invisible" : ""
         }`}
         onClick={handleStepForward}
@@ -71,7 +71,7 @@ export default function ControlPanel() {
         Étape suivante
       </button>
       <button
-        className={`w-full rounded bg-blue-500 px-4 py-2 text-white ${
+        className={`w-full cursor-pointer rounded bg-blue-500 px-4 py-2 text-white ${
           backHidden ? "invisible" : ""
         }`}
         onClick={handleStepBack}
@@ -80,7 +80,7 @@ export default function ControlPanel() {
         Étape précédente
       </button>
       <button
-        className={`w-full rounded px-4 py-2 text-white ${
+        className={`w-full cursor-pointer rounded px-4 py-2 text-white ${
           autoRunHidden ? "invisible" : ""
         }`}
         style={{ backgroundColor: autoRunning ? "#DC2626" : "#6B7280" }}
@@ -104,7 +104,7 @@ export default function ControlPanel() {
         </div>
       )}
       <button
-        className={`w-full rounded bg-yellow-500 px-4 py-2 text-white ${
+        className={`w-full cursor-pointer rounded bg-yellow-500 px-4 py-2 text-white ${
           debugHidden ? "invisible" : ""
         }`}
         onClick={handleToggleDebug}
@@ -113,7 +113,7 @@ export default function ControlPanel() {
         {debugMode ? "Quitter debug" : "Mode debug"}
       </button>
       <button
-        className={`w-full rounded bg-purple-500 px-4 py-2 text-white ${
+        className={`w-full cursor-pointer rounded bg-purple-500 px-4 py-2 text-white ${
           theoryHidden ? "invisible" : ""
         }`}
         onClick={handleToggleTheory}

--- a/src/components/TheorySlide.tsx
+++ b/src/components/TheorySlide.tsx
@@ -28,7 +28,7 @@ export default function TheorySlide({ onClose }: TheorySlideProps) {
         onClick={(e) => e.stopPropagation()}
       >
         <button
-          className="mb-4 rounded bg-gray-200 px-2 py-1 text-sm"
+          className="mb-4 cursor-pointer rounded bg-gray-200 px-2 py-1 text-sm"
           onClick={handleClose}
         >
           Fermer


### PR DESCRIPTION
## Summary
- document pointer cursor rule in UI specs
- add `cursor-pointer` on ControlPanel buttons
- ensure close button on theory slide also uses `cursor-pointer`

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68812244cee0832585f14ecc744c436e