### PR TITLE
feat: color nodes when SCCs found

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -11,6 +11,17 @@ import { getNextNodeLabel } from "../utils/graphHelpers";
 import { useAlgoStore } from "../store/algoState";
 import { useShallow } from "zustand/react/shallow";
 
+const SCC_COLORS = [
+  "fill-red-300",
+  "fill-green-300",
+  "fill-blue-300",
+  "fill-indigo-300",
+  "fill-pink-300",
+  "fill-amber-300",
+  "fill-lime-300",
+  "fill-teal-300",
+];
+
 interface DragEventLike {
   x: number;
   y: number;
@@ -56,9 +67,20 @@ export default function GraphCanvas() {
       if (selectedNodeForEdge === n.id) {
         return `${baseClass} fill-yellow-300`;
       }
-      return selectedNodes.includes(n.id)
-        ? `${baseClass} fill-gray-300`
-        : `${baseClass} fill-white`;
+      if (selectedNodes.includes(n.id)) {
+        return `${baseClass} fill-gray-300`;
+      }
+      if (n.status.sccIndex !== null) {
+        const color = SCC_COLORS[n.status.sccIndex % SCC_COLORS.length];
+        return `${baseClass} ${color}`;
+      }
+      if (n.status.onStack) {
+        return `${baseClass} fill-yellow-200`;
+      }
+      if (n.status.visited) {
+        return `${baseClass} fill-gray-200`;
+      }
+      return `${baseClass} fill-white`;
     },
     [selectedNodes, selectedNodeForEdge],
   );


### PR DESCRIPTION
## Summary
- color nodes with a palette once they belong to a strongly connected component

## Testing
- `bun run lint`
- `bun run build`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68812a32c83c832598ba31c41e71d1b6