### PR TITLE
Add crosshair cursor when canvas can add nodes

### DIFF
--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -277,10 +277,13 @@ export default function GraphCanvas() {
     setCursor,
   ]);
 
+  const crosshair =
+    editable && editMode === "none" && cursor === "" ? "cursor-crosshair" : "";
+
   return (
     <svg
       ref={svgRef}
-      className={`h-full w-full rounded bg-white shadow ${cursor}`}
+      className={`h-full w-full rounded bg-white shadow ${crosshair} ${cursor}`}
       onClick={handleCanvasClick}
       onMouseLeave={() => setCursor("")}
     />


### PR DESCRIPTION
## Summary
- show a crosshair cursor when the canvas is ready for node creation

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68812c71b1bc8325a14ef28a1e23d5b9