### PR TITLE
Display node labels in AlgorithmConsole

### DIFF
--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -12,13 +12,10 @@ export default function AlgorithmConsole() {
   );
   const nodes = useGraphStore((s) => s.nodes);
 
-  const idToLabel = new Map(nodes.map((n) => [n.id, n.label]));
-
   const rows = [...nodes]
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) => a.id.localeCompare(b.id))
     .map((n) => ({
       id: n.id,
-      label: n.label,
       index: indexMap.get(n.id) ?? "—",
       lowlink: lowLinkMap.get(n.id) ?? "—",
     }));
@@ -38,7 +35,7 @@ export default function AlgorithmConsole() {
           <tbody>
             {rows.map((r) => (
               <tr key={r.id} className="odd:bg-white even:bg-gray-50">
-                <td className="border border-gray-300 px-2 py-1">{r.label}</td>
+                <td className="border border-gray-300 px-2 py-1">{r.id}</td>
                 <td className="border border-gray-300 px-2 py-1">{r.index}</td>
                 <td className="border border-gray-300 px-2 py-1">
                   {r.lowlink}
@@ -53,7 +50,7 @@ export default function AlgorithmConsole() {
         <ul className="divide-y divide-gray-300 border border-gray-300 bg-gray-50">
           {stack.map((id) => (
             <li key={id} className="px-2 py-1">
-              {idToLabel.get(id) ?? id}
+              {id}
             </li>
           ))}
         </ul>

--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -12,8 +12,11 @@ export default function AlgorithmConsole() {
   );
   const nodes = useGraphStore((s) => s.nodes);
 
+  const idToLabel = new Map(nodes.map((n) => [n.id, n.label]));
+
   const rows = nodes.map((n) => ({
     id: n.id,
+    label: n.label,
     index: indexMap.get(n.id) ?? "—",
     lowlink: lowLinkMap.get(n.id) ?? "—",
   }));
@@ -22,20 +25,20 @@ export default function AlgorithmConsole() {
     <div className="space-y-4">
       <div>
         <h3 className="font-semibold">Index / Lowlink</h3>
-        <table className="w-full text-left border border-gray-300">
+        <table className="w-full border border-gray-300 text-left">
           <thead className="bg-gray-200">
             <tr>
-              <th className="px-2 py-1 border border-gray-300">Nœud</th>
-              <th className="px-2 py-1 border border-gray-300">Index</th>
-              <th className="px-2 py-1 border border-gray-300">Lowlink</th>
+              <th className="border border-gray-300 px-2 py-1">Nœud</th>
+              <th className="border border-gray-300 px-2 py-1">Index</th>
+              <th className="border border-gray-300 px-2 py-1">Lowlink</th>
             </tr>
           </thead>
           <tbody>
             {rows.map((r) => (
               <tr key={r.id} className="odd:bg-white even:bg-gray-50">
-                <td className="px-2 py-1 border border-gray-300">{r.id}</td>
-                <td className="px-2 py-1 border border-gray-300">{r.index}</td>
-                <td className="px-2 py-1 border border-gray-300">
+                <td className="border border-gray-300 px-2 py-1">{r.label}</td>
+                <td className="border border-gray-300 px-2 py-1">{r.index}</td>
+                <td className="border border-gray-300 px-2 py-1">
                   {r.lowlink}
                 </td>
               </tr>
@@ -45,10 +48,10 @@ export default function AlgorithmConsole() {
       </div>
       <div>
         <h3 className="font-semibold">Pile</h3>
-        <ul className="border border-gray-300 bg-gray-50 divide-y divide-gray-300">
+        <ul className="divide-y divide-gray-300 border border-gray-300 bg-gray-50">
           {stack.map((id) => (
             <li key={id} className="px-2 py-1">
-              {id}
+              {idToLabel.get(id) ?? id}
             </li>
           ))}
         </ul>

--- a/src/components/AlgorithmConsole.tsx
+++ b/src/components/AlgorithmConsole.tsx
@@ -14,12 +14,14 @@ export default function AlgorithmConsole() {
 
   const idToLabel = new Map(nodes.map((n) => [n.id, n.label]));
 
-  const rows = nodes.map((n) => ({
-    id: n.id,
-    label: n.label,
-    index: indexMap.get(n.id) ?? "—",
-    lowlink: lowLinkMap.get(n.id) ?? "—",
-  }));
+  const rows = [...nodes]
+    .sort((a, b) => a.label.localeCompare(b.label))
+    .map((n) => ({
+      id: n.id,
+      label: n.label,
+      index: indexMap.get(n.id) ?? "—",
+      lowlink: lowLinkMap.get(n.id) ?? "—",
+    }));
 
   return (
     <div className="space-y-4">

--- a/src/components/GraphCanvas.tsx
+++ b/src/components/GraphCanvas.tsx
@@ -7,7 +7,6 @@ import {
   type GraphNode,
   type GraphEdge,
 } from "../store/graphStore";
-import { getNextNodeLabel } from "../utils/graphHelpers";
 import { useAlgoStore } from "../store/algoState";
 import { useShallow } from "zustand/react/shallow";
 
@@ -125,11 +124,10 @@ export default function GraphCanvas() {
       const y = event.clientY - bounds.top;
       addGraphNode({
         id: getNextNodeId(),
-        label: getNextNodeLabel(nodes),
         position: { x, y },
       });
     },
-    [editable, editMode, getNextNodeId, addGraphNode, nodes],
+    [editable, editMode, getNextNodeId, addGraphNode],
   );
 
   useEffect(() => {
@@ -266,7 +264,7 @@ export default function GraphCanvas() {
       .append("text")
       .attr("text-anchor", "middle")
       .attr("dy", ".35em")
-      .text((d: GraphNode) => d.label);
+      .text((d: GraphNode) => d.id);
   }, [
     nodes,
     edges,

--- a/src/store/graphStore.ts
+++ b/src/store/graphStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { useAlgoStore } from "./algoState";
+import { getNextNodeId as computeNextNodeId } from "../utils/graphHelpers";
 
 export type NodeId = string;
 
@@ -89,9 +90,12 @@ export const useGraphStore = create<GraphStore>((set, get) => ({
   setEditMode: (mode) => set({ editMode: mode }),
 
   getNextNodeId: () => {
-    const count = get().nodeCount + 1;
-    set({ nodeCount: count });
-    return `N${count}`;
+    const id = computeNextNodeId(get().nodes);
+    const num = Number(id.slice(1));
+    if (num > get().nodeCount) {
+      set({ nodeCount: num });
+    }
+    return id;
   },
 
   setSelectedNodeForEdge: (id) => set({ selectedNodeForEdge: id }),

--- a/src/store/graphStore.ts
+++ b/src/store/graphStore.ts
@@ -11,7 +11,6 @@ export interface NodeStatus {
 
 export interface GraphNode {
   id: NodeId;
-  label: string;
   position: { x: number; y: number };
   status: NodeStatus;
 }
@@ -92,7 +91,7 @@ export const useGraphStore = create<GraphStore>((set, get) => ({
   getNextNodeId: () => {
     const count = get().nodeCount + 1;
     set({ nodeCount: count });
-    return `node-${count}`;
+    return `N${count}`;
   },
 
   setSelectedNodeForEdge: (id) => set({ selectedNodeForEdge: id }),

--- a/src/utils/graphHelpers.ts
+++ b/src/utils/graphHelpers.ts
@@ -1,16 +1,16 @@
-export interface LabeledNode {
-  label: string;
+export interface IdNode {
+  id: string;
 }
 
 /**
- * Return a label "N<number>" filling gaps in existing nodes labels.
+ * Return an id "N<number>" filling gaps in existing node ids.
  * If numbers 1..n contain holes, the smallest missing number is used.
  * Otherwise returns N<nodes.length + 1>.
  */
-export function getNextNodeLabel(nodes: LabeledNode[]): string {
+export function getNextNodeId(nodes: IdNode[]): string {
   const used = new Set<number>();
   for (const n of nodes) {
-    const match = /^N(\d+)$/.exec(n.label);
+    const match = /^N(\d+)$/.exec(n.id);
     if (match) {
       used.add(Number(match[1]));
     }

--- a/src/utils/tarjan.ts
+++ b/src/utils/tarjan.ts
@@ -1,5 +1,5 @@
 export type Graph = {
-  nodes: { id: string; label?: string }[];
+  nodes: { id: string }[];
   edges: { from: string; to: string }[];
 };
 
@@ -30,13 +30,7 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
   const sccs: string[][] = [];
   let index = 0;
 
-  const sortedNodes = [...graph.nodes].sort((a, b) => {
-    const la = a.label ?? a.id;
-    const lb = b.label ?? b.id;
-    return la.localeCompare(lb);
-  });
-
-  const idToLabel = new Map(sortedNodes.map((n) => [n.id, n.label ?? n.id]));
+  const sortedNodes = [...graph.nodes].sort((a, b) => a.id.localeCompare(b.id));
 
   const adjacency = new Map<string, string[]>();
   for (const node of sortedNodes) {
@@ -47,11 +41,7 @@ export function* tarjanStepByStep(graph: Graph): Generator<TarjanStateUpdate> {
     if (list) list.push(edge.to);
   }
   for (const list of adjacency.values()) {
-    list.sort((a, b) => {
-      const la = idToLabel.get(a) ?? a;
-      const lb = idToLabel.get(b) ?? b;
-      return la.localeCompare(lb);
-    });
+    list.sort((a, b) => a.localeCompare(b));
   }
 
   function snapshot(


### PR DESCRIPTION
## Summary
- show node labels instead of node ids in `AlgorithmConsole`

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_6881e66eec0c8325ade0645cccccf255